### PR TITLE
command-line option to control unit of time

### DIFF
--- a/line_profiler/line_profiler.py
+++ b/line_profiler/line_profiler.py
@@ -421,11 +421,25 @@ def main():
     parser = optparse.OptionParser(usage=usage,
                                    version=__version__)
 
+    parser.add_option('-u', '--unit', default=None,
+                      help="specify the unit of time")
+
     options, args = parser.parse_args()
     if len(args) != 1:
         parser.error("Must provide a filename.")
+        
+    output_unit = None
+    try:
+        if options.unit is not None:
+            time_unit = float(options.unit)
+            if time_unit != 0:
+                output_unit = time_unit
+    except:
+        pass
+    
     lstats = load_stats(args[0])
-    show_text(lstats.timings, lstats.unit)
+    show_text(lstats.timings, lstats.unit,
+              output_unit=output_unit)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
https://github.com/rkern/line_profiler/issues/136#issuecomment-461966219
add a command line option -u --unit to specify the unit of time displayed by line_profiler for ease of use and ease of reading the result.
Windows defaults to 1e-7 whereas specifying 1e-6 would be easier to read and mentally parse.
The user can easily change the unit if the runtimes are expected to be long eg: seconds

eg: to specify a time unit of 1us on the output of kernprof "script.lprof"
python -m line_profiler ./script.lprof -u 1e-6 