### PR TITLE
command-line option to profile all functions

### DIFF
--- a/kernprof.py
+++ b/kernprof.py
@@ -337,6 +337,8 @@ def main(args=None):
                     execfile_inject(script_file, ns, ns, options.include, options.exclude, 
                                     options.auto_find, options.auto_before, options.module)
                 except (KeyboardInterrupt, SystemExit):
+                    pass
+                except:
                     if options.builtin:
                         execfile(script_file, ns, ns)
                     else:

--- a/kernprof.py
+++ b/kernprof.py
@@ -91,7 +91,7 @@ def execfile_inject(filename, globals=None, locals=None, include=None, exclude=N
 {0}        exclude_ = [x.strip() for x in exclude_]
 {0}        if type(fn_) is dict:
 {0}            for name in fn_:
-{0}                if name not in ['execfile_','decorate_all_in']:
+{0}                if name not in ['execfile_','execfile_inject','decorate_with']:
 {0}                    if not len(include_) or name in include_:
 {0}                        if not len(exclude_) or name not in exclude_:
 {0}                            if inspect.isfunction(fn_[name]):


### PR DESCRIPTION
add param "-a", "--auto" to automatically profile all functions and classes in script by inserting code after "if __name__ == '__main__':" in the script

kernprof with line_profiler requires the user to manually decorate the functions they want to profile as it is not feasible to profile all the code.
This can be arduous to decorate all functions, and in some cases it might not be possible to modify the script that they want to profile.

This param will allow the user to decorate all functions and classes inside the specified script from the command line. which means solves the problem of manually decorating all the functions, or if the user cannot modify the script.

Due to the fact that line_profiler will output all the decorated functions even if they are not run, to reduce clutter it is best to use with the new param added in another commit that skips displaying non-run functions